### PR TITLE
feat(daily-guides): add bold to current shard eruption

### DIFF
--- a/apps/website/app/routes/daily-guides.tsx
+++ b/apps/website/app/routes/daily-guides.tsx
@@ -724,7 +724,9 @@ export default function DailyGuides({ loaderData }: Route.ComponentProps) {
 															"text-xs",
 															end.unix < epochSeconds(now)
 																? "text-gray-400 line-through dark:text-gray-500"
-																: "text-gray-600 dark:text-gray-300",
+																: epochSeconds(now) > start.unix
+																	? "text-gray-900 font-bold dark:text-white"
+																	: "text-gray-600 dark:text-gray-300",
 														)}
 													>
 														{t("time-range", {
@@ -780,7 +782,9 @@ export default function DailyGuides({ loaderData }: Route.ComponentProps) {
 														"text-xs",
 														end.unix < epochSeconds(now)
 															? "text-gray-400 line-through dark:text-gray-500"
-															: "text-gray-600 dark:text-gray-300",
+															: epochSeconds(now) > start.unix
+																? "text-gray-900 font-bold dark:text-white"
+																: "text-gray-600 dark:text-gray-300",
 													)}
 												>
 													{t("time-range", { ns: "general", start: start.format, end: end.format })}


### PR DESCRIPTION
Shards on the daily guides page could be more visible while they are occurring :

**Dark theme :**
<img width="664" height="394" alt="dark" src="https://github.com/user-attachments/assets/8fbb15d8-b7d0-4c79-aae8-1e54359e151e" />

**Light theme :**
<img width="664" height="394" alt="light" src="https://github.com/user-attachments/assets/f0b65afe-893b-487a-bb31-bc606922d549" />

For the `shard-eruption` page I don’t think it’s necessary, it’s preferable to keep all shards times well visible as they currently are. 